### PR TITLE
Feature/add bypassable exceptions and make injectable service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,17 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.21.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-surefire-provider</artifactId>
+                        <version>1.2.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
     <packaging>jar</packaging>
@@ -32,6 +43,12 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/qudini/exceptions/ExceptionsService.java
+++ b/src/main/java/com/qudini/exceptions/ExceptionsService.java
@@ -51,10 +51,9 @@ public class ExceptionsService {
     }
 
     private boolean toBeBypassed(Exception exception) {
-        Class<?> exceptionClass = exception.getClass();
         return exceptionsToIgnore
                 .stream()
-                .anyMatch(toIgnore -> toIgnore.isAssignableFrom(exceptionClass));
+                .anyMatch(toIgnore -> toIgnore.isInstance(exception));
     }
 
     /**
@@ -127,9 +126,11 @@ public class ExceptionsService {
         } catch (Exception e) {
             if (toBeBypassed(e)) {
                 throwUnchecked(e);
+                throw new InvalidCodePathException();
+            } else {
+                reporters.forEach(reporter -> reporter.report(e));
+                return Optional.empty();
             }
-            reporters.forEach(reporter -> reporter.report(e));
-            return Optional.empty();
         }
     }
 

--- a/src/main/java/com/qudini/exceptions/ExceptionsService.java
+++ b/src/main/java/com/qudini/exceptions/ExceptionsService.java
@@ -1,0 +1,222 @@
+package com.qudini.exceptions;
+
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
+
+/**
+ * Utilities for handling exceptions. These include:
+ * <ul>
+ * <li>Turning checked exceptions into unchecked ones.</li>
+ * <li>Converting all checked exceptions thrown in a code block to unchecked.</li>
+ * <li>
+ * Reporting exceptions through application-specific error-reporting tools, but continuing as usual afterwards
+ * </li>
+ * <li>
+ * Reporting exceptions through application-specific error-reporting tools, and then rethrowing the exception.
+ * </li>
+ * </ul>
+ */
+@CheckReturnValue
+public class ExceptionsService {
+
+    private final Set<Class<? extends Exception>> exceptionsToIgnore;
+
+    private ExceptionsService(Set<Class<? extends Exception>> exceptionsToIgnore) {
+        this.exceptionsToIgnore = exceptionsToIgnore;
+    }
+
+    /**
+     * @return exception utilities that work on all exceptions derived from `java.lang.Exception`.
+     */
+    public static ExceptionsService forAll() {
+        return new ExceptionsService(emptySet());
+    }
+
+    /**
+     * @return exception utilities that work on all exceptions derived from `java.lang.Exception`, except for
+     * {@code exceptionsToIgnore}. These exceptions work as if these utilities were not used at all; for example,
+     * {@link #reportQuietly} and {@link #reportAndRethrow} will not report these and just keep throwing the exception
+     * as normal.
+     */
+    public static ExceptionsService bypassing(Class<? extends Exception>... exceptionsToIgnore) {
+        return new ExceptionsService(new HashSet<>(asList(exceptionsToIgnore)));
+    }
+
+    private boolean toBeBypassed(Exception exception) {
+        Class<?> exceptionClass = exception.getClass();
+        return exceptionsToIgnore
+                .stream()
+                .anyMatch(toIgnore -> toIgnore.isAssignableFrom(exceptionClass));
+    }
+
+    /**
+     * Throws an exception at runtime, even if it's compile-checked.
+     * <p>
+     * This is useful for using APIs which misuse compile-checked exceptions, forcing its consumers to code verbosely
+     * and to leak implementation details. This also alleviates the annoying interplay between lambdas and
+     * compile-checked exceptions.
+     */
+    public void throwUnchecked(final Exception exception) {
+        try {
+            throw exception;
+        } catch (final RuntimeException rethrownException) {
+            throw rethrownException;
+        } catch (final Exception rethrownException) {
+            throw new RuntimeCheckedException(rethrownException);
+        }
+    }
+
+    /**
+     * Runs a block of code in which compile-time exceptions are converted to runtime exceptions.
+     */
+    public <T> T unchecked(PotentiallyErroneous<T> f) {
+        try {
+            return f.run();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception t) {
+            throw new RuntimeCheckedException(t);
+        }
+    }
+
+    /**
+     * Runs a block of code in which compile-time exceptions are converted to runtime exceptions.
+     */
+    public void unchecked(PotentiallyErroneousWithoutResult f) {
+        try {
+            f.run();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception t) {
+            throw new RuntimeCheckedException(t);
+        }
+    }
+
+    /**
+     * Report errors but continue without throwing an exception. This is designed for events whose breakages should be
+     * logged, but should not break execution flow.
+     * <p>
+     * Eg.:
+     * <pre>{@code
+     * return Exceptions.reportQuietly(
+     *         Arrays.asList(
+     *                 new NewRelicReporter(),
+     *                 (message, exception) -> myOwnHandler(exception)
+     *         ),
+     *         () -> {
+     *             doSomethingThatMayCrash1();
+     *             doSomethingThatMayCrash2();
+     *             return successfulResult;
+     *         }
+     * );
+     * }</pre>
+     * <p>
+     */
+    @Nonnull
+    public <A> Optional<A> reportQuietly(List<? extends Reporter> reporters, PotentiallyErroneous<A> f) {
+        try {
+            return Optional.of(f.run());
+        } catch (Exception e) {
+            if (toBeBypassed(e)) {
+                throwUnchecked(e);
+            }
+            reporters.forEach(reporter -> reporter.report(e));
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * @see #reportQuietly(List, PotentiallyErroneous)
+     */
+    public void reportQuietly(List<? extends Reporter> reporters, PotentiallyErroneousWithoutResult f) {
+
+        // The only case where @CheckReturnValue should be ignored for `#reportQuietly`.
+        reportQuietly(reporters, () -> {
+            f.run();
+
+            // A silly throwaway value, since the only valid value of Void is null, which crashes `Optional#of`.
+            return Boolean.TRUE;
+        });
+    }
+
+    /**
+     * Report errors and then continue throwing the exception. This is designed for exceptions that we want explicitly
+     * to be logged to services like NewRelic.
+     * <p>
+     * Eg.:
+     * <pre>{@code
+     * return Exceptions.reportAndRethrow(
+     *         Arrays.asList(
+     *                 new NewRelicReporter(),
+     *                 (message, exception) -> myOwnHandler(exception)
+     *         ),
+     *         () -> {
+     *             doSomethingThatMayCrash1();
+     *             doSomethingThatMayCrash2();
+     *             return successfulResult;
+     *         }
+     * );
+     * }</pre>
+     */
+    @Nonnull
+    public <A> A reportAndRethrow(List<? extends Reporter> reporters, PotentiallyErroneous<A> f) {
+        try {
+            return f.run();
+        } catch (Exception e) {
+            if (!toBeBypassed(e)) {
+                reporters.forEach(reporter -> reporter.report(e));
+            }
+            throwUnchecked(e);
+            throw new InvalidCodePathException();
+        }
+    }
+
+    /**
+     * @see #reportAndRethrow(List, PotentiallyErroneous)
+     */
+    public void reportAndRethrow(List<? extends Reporter> reporters, PotentiallyErroneousWithoutResult f) {
+
+        // The only case where @CheckReturnValue should be ignored for `#reportAndRethrow`.
+        reportAndRethrow(reporters, () -> {
+            f.run();
+
+            // A silly throwaway value, since the only valid value of Void is null, which crashes `Optional#of`.
+            return Boolean.TRUE;
+        });
+    }
+
+    /**
+     * @see #reportQuietly(List, PotentiallyErroneous)
+     */
+    @FunctionalInterface
+    public interface PotentiallyErroneous<A> {
+
+        @CheckReturnValue
+        A run() throws Exception;
+    }
+
+    /**
+     * @see #reportQuietly(List, PotentiallyErroneousWithoutResult)
+     */
+    @FunctionalInterface
+    public interface PotentiallyErroneousWithoutResult {
+        void run() throws Exception;
+    }
+
+    @FunctionalInterface
+    public interface Reporter {
+        void report(String message, Exception cause);
+
+        default void report(Exception cause) {
+            report(cause.getMessage(), cause);
+        }
+    }
+}

--- a/src/test/java/com/qudini/exceptions/ExceptionsServiceTest.java
+++ b/src/test/java/com/qudini/exceptions/ExceptionsServiceTest.java
@@ -1,0 +1,102 @@
+package com.qudini.exceptions;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ExceptionsServiceTest {
+
+    private ExceptionsService exceptionsServiceForAll = ExceptionsService.forAll();
+    private ExceptionsService exceptionsServiceExcluding = ExceptionsService.bypassing(
+            ExcludedException1.class,
+            ExcludedException2.class
+    );
+
+    @Test
+    public void throwUnchecked() {
+        try {
+            exceptionsServiceForAll.throwUnchecked(new Exception());
+        } catch (RuntimeException exception) {
+            return;
+        }
+        fail();
+    }
+
+    @Test
+    public void unchecked() {
+        try {
+            exceptionsServiceForAll.unchecked((ExceptionsService.PotentiallyErroneousWithoutResult) () -> {
+                throw new ExcludedException2();
+            });
+
+            fail();
+        } catch (Exception exception) {
+            assertTrue(exception.getCause() instanceof ExcludedException2);
+        }
+
+        try {
+            exceptionsServiceForAll.unchecked(() -> {
+                throw new UnsupportedOperationException();
+            });
+
+            fail();
+        } catch (UnsupportedOperationException exception) {
+        }
+    }
+
+    @Test
+    public void reportQuietly() {
+        exceptionsServiceForAll.reportQuietly(emptyList(), () -> {
+            throw new Exception();
+        });
+
+        try {
+            exceptionsServiceExcluding.reportQuietly(emptyList(), () -> {
+                throw new ExcludedException1();
+            });
+            fail();
+        } catch (ExcludedException1 exception) {
+        }
+    }
+
+    @Test
+    public void reportAndRethrow() {
+        AtomicInteger reportCount = new AtomicInteger();
+        List<ExceptionsService.Reporter> reporters = singletonList((e, m) -> reportCount.incrementAndGet());
+
+        try {
+            exceptionsServiceForAll.reportAndRethrow(
+                    reporters,
+                    () -> {
+                        throw new UnsupportedOperationException();
+                    }
+            );
+            fail();
+        } catch (UnsupportedOperationException exception) {
+            assertEquals(reportCount.get(), 1);
+        }
+
+        try {
+            exceptionsServiceExcluding.reportAndRethrow(
+                    reporters,
+                    () -> {
+                        throw new ExcludedException1();
+                    }
+            );
+            fail();
+        } catch (ExcludedException1 exception) {
+            assertEquals(reportCount.get(), 1);
+        }
+    }
+
+    private final class ExcludedException1 extends RuntimeException {
+    }
+
+    private final class ExcludedException2 extends Exception {
+    }
+}

--- a/src/test/java/com/qudini/exceptions/ExceptionsTest.java
+++ b/src/test/java/com/qudini/exceptions/ExceptionsTest.java
@@ -1,0 +1,73 @@
+package com.qudini.exceptions;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ExceptionsTest {
+
+    @Test
+    public void throwUnchecked() {
+        try {
+            Exceptions.throwUnchecked(new Exception());
+        } catch (RuntimeException exception) {
+            return;
+        }
+        fail();
+    }
+
+    @Test
+    public void unchecked() {
+        try {
+            Exceptions.unchecked((Exceptions.PotentiallyErroneousWithoutResult) () -> {
+                throw new ExcludedException2();
+            });
+
+            fail();
+        } catch (Exception exception) {
+            assertTrue(exception.getCause() instanceof ExcludedException2);
+        }
+
+        try {
+            Exceptions.unchecked(() -> {
+                throw new UnsupportedOperationException();
+            });
+
+            fail();
+        } catch (UnsupportedOperationException exception) {
+        }
+    }
+
+    @Test
+    public void reportQuietly() {
+        Exceptions.reportQuietly(emptyList(), () -> {
+            throw new Exception();
+        });
+    }
+
+    @Test
+    public void reportAndRethrow() {
+        AtomicInteger reportCount = new AtomicInteger();
+        List<Exceptions.Reporter> reporters = singletonList((e, m) -> reportCount.incrementAndGet());
+
+        try {
+            Exceptions.reportAndRethrow(
+                    reporters,
+                    () -> {
+                        throw new UnsupportedOperationException();
+                    }
+            );
+            fail();
+        } catch (UnsupportedOperationException exception) {
+            assertEquals(reportCount.get(), 1);
+        }
+    }
+
+    private final class ExcludedException2 extends Exception {
+    }
+}


### PR DESCRIPTION
This turns `Exceptions` into an injectable service that can specify exceptions to ignore in the constructor. This builds the base for ignoring Play Framework 1 results as exceptions.

The new injectable service is called `ExceptionService`; the old `Exceptions` class maintains full backwards compatibility despite being deprecated.

Also, tests were added for all methods, both the new service and the older deprecated ones.